### PR TITLE
Add binary name using qmake TARGET field

### DIFF
--- a/Cetus.pro
+++ b/Cetus.pro
@@ -1,3 +1,5 @@
+TARGET = cetus
+
 TEMPLATE = app
 
 QT += qml quick widgets


### PR DESCRIPTION
Linking fails on x86 linux, because default
name for binary is Cetus and there is already a dir by that
name in the repo tree

You could rename the dir, but traditionally all binaries 
under linux are lowercase amyway

Signed-off-by: Mick Grant arceye@mgware.co.uk
